### PR TITLE
Add ReencryptionController and ReencryptionService

### DIFF
--- a/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/config/Beans.java
+++ b/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/config/Beans.java
@@ -1,0 +1,18 @@
+package eu.elixir.ega.ebi.reencryptionmvc.config;
+
+import htsjdk.samtools.seekablestream.ISeekableStreamFactory;
+import htsjdk.samtools.seekablestream.SeekableStreamFactory;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableDiscoveryClient
+public class Beans {
+
+    @Bean
+    public ISeekableStreamFactory seekableStreamFactory() {
+        return SeekableStreamFactory.getInstance();
+    }
+
+}

--- a/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/domain/Format.java
+++ b/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/domain/Format.java
@@ -1,0 +1,7 @@
+package eu.elixir.ega.ebi.reencryptionmvc.domain;
+
+public enum Format {
+
+    PLAIN, AES, GPG
+
+}

--- a/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/rest/ReencryptionController.java
+++ b/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/rest/ReencryptionController.java
@@ -1,0 +1,57 @@
+package eu.elixir.ega.ebi.reencryptionmvc.rest;
+
+import eu.elixir.ega.ebi.reencryptionmvc.domain.Format;
+import eu.elixir.ega.ebi.reencryptionmvc.service.ReencryptionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.InputStream;
+
+// Test files can be found at "src/test/resources/htsjdk/samtools/seekablestream/cipher/" under ega-htsdjk project
+// http://localhost:8080/download?fileLocation=/lorem.aes.enc&startByte=10&endByte=20&sourceFormat=AES&sourceKey=/ega.sec&targetFormat=GPG&targetKey=/public.key
+@EnableDiscoveryClient
+@RequestMapping("/download")
+@RestController
+public class ReencryptionController {
+
+    private static final String CONTENT_DISPOSITION_PREFIX = "attachment; filename=";
+
+    private ReencryptionService reencryptionService;
+
+    @GetMapping
+    @ResponseBody
+    public ResponseEntity<Resource> download(@RequestParam(value = "sourceFormat", required = false, defaultValue = "plain") String sourceFormat,
+                                             @RequestParam(value = "sourceKey", required = false) String sourceKey,
+                                             @RequestParam(value = "targetFormat", required = false, defaultValue = "plain") String targetFormat,
+                                             @RequestParam(value = "targetKey", required = false) String targetKey,
+                                             @RequestParam(value = "fileLocation") String fileLocation,
+                                             @RequestParam(value = "startByte", required = false, defaultValue = "0") long startByte,
+                                             @RequestParam(value = "endByte", required = false, defaultValue = "0") long endByte) throws Exception {
+        InputStream inputStream = reencryptionService.getInputStream(Format.valueOf(sourceFormat.toUpperCase()),
+                sourceKey,
+                Format.valueOf(targetFormat.toUpperCase()),
+                targetKey,
+                fileLocation,
+                startByte,
+                endByte);
+        InputStreamResource file = new InputStreamResource(inputStream);
+        return ResponseEntity
+                .ok()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
+                .header(HttpHeaders.CONTENT_DISPOSITION, CONTENT_DISPOSITION_PREFIX + StringUtils.getFilename(fileLocation))
+                .body(file);
+    }
+
+    @Autowired
+    public void setReencryptionService(ReencryptionService reencryptionService) {
+        this.reencryptionService = reencryptionService;
+    }
+
+}

--- a/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/service/ReencryptionService.java
+++ b/src/main/java/eu/elixir/ega/ebi/reencryptionmvc/service/ReencryptionService.java
@@ -1,0 +1,92 @@
+package eu.elixir.ega.ebi.reencryptionmvc.service;
+
+import eu.elixir.ega.ebi.reencryptionmvc.domain.Format;
+import htsjdk.samtools.seekablestream.ISeekableStreamFactory;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.seekablestream.cipher.GPGCipherStream;
+import htsjdk.samtools.seekablestream.cipher.SeekableAESCipherStream;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openpgp.*;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.bouncycastle.util.io.pem.PemReader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import java.io.*;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Iterator;
+import java.util.Objects;
+
+@Service
+public class ReencryptionService {
+
+    private ISeekableStreamFactory seekableStreamFactory;
+
+    @PostConstruct
+    private void init() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    public InputStream getInputStream(Format sourceFormat,
+                                      String sourceKey,
+                                      Format targetFormat,
+                                      String targetKey,
+                                      String fileLocation,
+                                      long startCoordinate,
+                                      long endCoordinate) throws IOException, NoSuchPaddingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IllegalBlockSizeException, BadPaddingException, NoSuchProviderException, InvalidKeyException, InvalidKeySpecException, PGPException {
+        SeekableStream seekableStream = seekableStreamFactory.getStreamFor(fileLocation);
+        if (Format.AES.equals(sourceFormat)) {
+            seekableStream = new SeekableAESCipherStream(seekableStream, Objects.requireNonNull(getAESPrivateKey(sourceKey)));
+        }
+        seekableStream.seek(startCoordinate);
+        InputStream inputStream = endCoordinate != 0 && endCoordinate > startCoordinate ?
+                new BoundedInputStream(seekableStream, endCoordinate - startCoordinate) :
+                seekableStream;
+        if (Format.GPG.equals(targetFormat)) {
+            inputStream = new GPGCipherStream(inputStream, Objects.requireNonNull(getPGPPublicKey(targetKey)), StringUtils.getFilename(fileLocation));
+        }
+        return inputStream;
+    }
+
+    private byte[] getAESPrivateKey(String sourceKey) throws IOException {
+        try (PemReader pemReader = new PemReader(new InputStreamReader(new FileInputStream(sourceKey)))) {
+            return pemReader.readPemObject().getContent();
+        }
+    }
+
+    private PGPPublicKey getPGPPublicKey(String targetKey) throws IOException, PGPException {
+        InputStream in = new FileInputStream(new File(targetKey));
+        in = PGPUtil.getDecoderStream(in);
+        PGPPublicKeyRingCollection pgpPublicKeyRings = new PGPPublicKeyRingCollection(in, new BcKeyFingerprintCalculator());
+        PGPPublicKey pgpPublicKey = null;
+        Iterator keyRings = pgpPublicKeyRings.getKeyRings();
+        while (pgpPublicKey == null && keyRings.hasNext()) {
+            PGPPublicKeyRing kRing = (PGPPublicKeyRing) keyRings.next();
+            Iterator publicKeys = kRing.getPublicKeys();
+            while (publicKeys.hasNext()) {
+                PGPPublicKey key = (PGPPublicKey) publicKeys.next();
+                if (key.isEncryptionKey()) {
+                    pgpPublicKey = key;
+                    break;
+                }
+            }
+        }
+        if (pgpPublicKey == null) {
+            throw new IllegalArgumentException("Can't find encryption key in key ring.");
+        }
+        return pgpPublicKey;
+    }
+
+    @Autowired
+    public void setSeekableStreamFactory(ISeekableStreamFactory seekableStreamFactory) {
+        this.seekableStreamFactory = seekableStreamFactory;
+    }
+
+}


### PR DESCRIPTION
Test files can be found at "src/test/resources/htsjdk/samtools/seekablestream/cipher/" under ega-htsdjk project.

Usage: `http://localhost:8080/download?fileLocation=/lorem.aes.enc&startByte=10&endByte=20&sourceFormat=AES&sourceKey=/ega.sec&targetFormat=GPG&targetKey=/public.key`

All parameters are optional, except for `fileLocation`.